### PR TITLE
Fix _icds[] index collision in recursive ICD scan (build 1)

### DIFF
--- a/recipe/check_icds_recursively.diff
+++ b/recipe/check_icds_recursively.diff
@@ -1,8 +1,6 @@
-diff --git a/ocl_icd_loader.c b/ocl_icd_loader.c
-index 12e0182..10f13d7 100644
 --- a/ocl_icd_loader.c
 +++ b/ocl_icd_loader.c
-@@ -183,26 +183,59 @@ static inline int _string_with_slash(const char* str) {
+@@ -183,26 +183,59 @@
    return strchr(str, '/') != NULL;
  }
  
@@ -67,9 +65,13 @@ index 12e0182..10f13d7 100644
    RETURN(num_lays);
  }
  
-@@ -277,12 +310,22 @@ static inline unsigned int _open_driver(unsigned int num_icds,
- static inline unsigned int _open_drivers(DIR *dir, const char* dir_path) {
-   unsigned int num_icds = 0;
+@@ -274,15 +307,24 @@
+   RETURN(num_icds);
+ }
+ 
+-static inline unsigned int _open_drivers(DIR *dir, const char* dir_path) {
+-  unsigned int num_icds = 0;
++static inline unsigned int _open_drivers(DIR *dir, const char* dir_path, unsigned int num_icds) {
    struct dirent *ent;
 +  DIR * link_dir = NULL;
 +  char * link_dir_path;
@@ -84,7 +86,7 @@ index 12e0182..10f13d7 100644
 +      sprintf(link_dir_path,"%s/%s", dir_path, ent->d_name);
 +      link_dir = opendir(link_dir_path);
 +      if (link_dir != NULL) {
-+        num_icds += _open_drivers(link_dir, link_dir_path);
++        num_icds = _open_drivers(link_dir, link_dir_path, num_icds);
 +        closedir(link_dir);
 +      }
 +      free(link_dir_path);
@@ -94,7 +96,7 @@ index 12e0182..10f13d7 100644
    }
    RETURN(num_icds);
  }
-@@ -857,7 +900,7 @@ static void __initClIcd( void ) {
+@@ -889,7 +931,7 @@
        goto abort;
      }
  
@@ -103,3 +105,12 @@ index 12e0182..10f13d7 100644
      if(num_icds == 0) {
        goto abort;
      }
+@@ -913,7 +955,7 @@
+       num_icds = _load_icd(0, dir_path);
+     }
+   } else {
+-    num_icds = _open_drivers(dir, dir_path);
++    num_icds = _open_drivers(dir, dir_path, 0);
+   }
+   if(num_icds == 0) {
+     goto abort;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - check_icds_recursively.diff
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
   run_exports:
     - {{ pin_subpackage("ocl-icd") }}


### PR DESCRIPTION
Without this, things were crashing on my computer that had dual GPUs, intel integrated and NVidia discrete


<details><summary>Claude's draft</summary>

The check_icds_recursively.diff patch made _open_drivers() recurse into subdirectories of the vendor dir (needed for the ocl-icd-system symlink that exposes /etc/OpenCL/vendors). But _open_drivers kept a *local* `num_icds = 0` and used it as the write index into the global `_icds[]` array, while the recursive call restarted that index at 0. So an ICD found in a subdirectory was written to `_icds[0]`, overwriting an ICD already loaded from the parent dir, and the slot the count had reserved (`_icds[1]`, ...) was left UNINITIALIZED (the array is malloc'd, not zeroed). The uninitialized `dl_handle` is then passed to dlsym() during platform enumeration -> SIGSEGV.

Real-world trigger: a conda env with a conda Intel ICD (intel.icd in the prefix vendor dir) plus the system NVIDIA ICD reached recursively via the ocl-icd-system symlink. NVIDIA overwrote _icds[0] (Intel), _icds[1] was garbage, and clGetPlatformIDs crashed -- e.g. OpenVINO Core() device enumeration segfaulted on a hybrid Intel+NVIDIA laptop.

Fix: thread the running index through the recursion -- _open_drivers() takes the current num_icds and the recursive call continues from it (top-level caller passes 0). ICDs from subdirectories now land in the correct cumulative slots.

Verified on an Intel Arrow Lake + NVIDIA RTX 5070 laptop: with the system nvidia.icd present (no OCL_ICD_VENDORS workaround), OpenVINO now enumerates both GPU.0 (Intel iGPU) and GPU.1 (NVIDIA dGPU) and runs Intel GPU inference, no crash. Not a vendor/driver bug, not RTLD_DEEPBIND, not the ocl-icd version -- purely this patch's index handling.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume 8959e104-fade-4e06-a903-ec84f609fa1c
```
</details>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
